### PR TITLE
Add my June talk to the the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 =============
 
 ## 2017
-* [Seth Clark](https://github.com/setheclark)
-  * **Does It Work: The Basics of Testing** (April 12th)
-    * [Presentation](https://speakerdeck.com/setheclark/testing-basics)
+
+* April 12th
+	* **Does It Work: The Basics of Testing** - [Seth Clark](https://github.com/setheclark)
+		* [Presentation](https://speakerdeck.com/setheclark/testing-basics)
+* June 13th
+	* **Getting Started with Android Things** - [Jeb Ware](https://github.com/jebstuart)
+		* [Slides](https://docs.google.com/presentation/d/1VvgegWzco0fb85MEjh-tnzqvBz_Lkp0LCdJtSI4cnqA/pub?start=false&loop=false&delayms=3000)
+		* [Related Links](https://jebware.com/blog/?p=411)


### PR DESCRIPTION
I also re-organized it by date, instead of by presenter.  I figured that would be easier for somebody who was looking for info on a talk, but I'm open to comment there.  With some berating, I'd be willing to change it back and add my talk under the previous organization.